### PR TITLE
Switch to extended_yaml

### DIFF
--- a/lib/menu_commander/menu.rb
+++ b/lib/menu_commander/menu.rb
@@ -1,13 +1,12 @@
-require 'yaml'
-require 'yaml_extend'
 require 'tty/prompt'
+require 'extended_yaml'
 
 module MenuCommander
   class Menu
     attr_reader :config
 
     def initialize(config)
-      config = YAML.ext_load_file config if config.is_a? String
+      config = ExtendedYAML.load config if config.is_a? String
       @config = config
     end
 

--- a/menu_commander.gemspec
+++ b/menu_commander.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'mister_bin', '~> 0.3'
   s.add_runtime_dependency 'colsole', '~> 0.5'
   s.add_runtime_dependency 'tty-prompt', '~> 0.19'
-  s.add_runtime_dependency 'yaml_extend', '~> 0.2'
+  s.add_runtime_dependency 'extended_yaml', '~> 0.1'
 end


### PR DESCRIPTION
Switch from `yaml_extend` to `extended_yaml` for performance and simplicity.